### PR TITLE
Adds a [RENOVATE] commit message prefix.

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,6 +4,7 @@
   "dependencyDashboard": false,
   "reviewers": ["team:coresdk"],
   "labels": ["pr:dependencies"],
+  "commitMessagePrefix": "[RENOVATE]",
   "packageRules": [
     {
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Description
The `commitMessagePrefix` option is used for PR titles too. See the [docs](https://docs.renovatebot.com/configuration-options/#commitmessageprefix).