### PR TITLE
Adds purchases-android and purchases-hybrid-common.

### DIFF
--- a/.github/renovate-bot-config.js
+++ b/.github/renovate-bot-config.js
@@ -5,6 +5,8 @@ module.exports = {
   dryRun: null,
   repositories: [
     'RevenueCat/renovate',
+    'RevenueCat/purchases-android',
+    'RevenueCat/purchases-hybrid-common',
     'RevenueCat/purchases-flutter',
   ],
 };


### PR DESCRIPTION
## Description
I'll be adding new repos gradually, because after merging this and running Renovate again, it will open onboarding PRs in those repos. I'll then make sure they contain the right `renovate.json` config file (same as purchases-flutter). 