### PR TITLE
chore: pin actions/checkout to commit SHA

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.3
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Run Renovate
         uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
         with:


### PR DESCRIPTION
## Summary
- Pin all `uses:` references in GitHub Actions workflows to full SHA hashes (only `actions/checkout` was mising)
- Prevents supply chain attacks via tag mutation or typosquatting

## Context
- https://rosesecurity.dev/2026/03/20/typosquatting-trivy.html